### PR TITLE
enable_classiclink deprecated

### DIFF
--- a/workbook/Step_10.md
+++ b/workbook/Step_10.md
@@ -15,7 +15,6 @@ resource "aws_vpc" "work-vpc" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = "true" #gives you an internal domain name
   enable_dns_hostnames = "true" #gives you an internal host name
-  enable_classiclink   = "false"
   instance_tenancy     = "default"
 
   tags = {


### PR DESCRIPTION
enable_classiclink has been deprecated. This line produced an error when using terraform validate. Setting it to null threw and error but removing the line entirely solved the problem.